### PR TITLE
Added instructions for Unity Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,16 @@ zfc.exe -i "..\src\Sandbox.Shared.csproj" -s -o "..\unity\ZfcCompiled\"
 
 Generated formatters must need to register on Startup. By default, zfc generate automatic register code on `RuntimeInitializeOnLoad` timing.
 
+For Unity Unit Tests, the generated formatters must be registered in the `SetUp` method:
+
+```csharp
+    [SetUp]
+    public void RegisterZeroFormatter()
+    {
+        ZeroFormatterInitializer.Register();
+    }
+```
+
 ZeroFormatter can not serialize Unity native types by default but you can make custom formatter by define pseudo type. For example create `Vector2` to ZeroFormatter target. 
 
 ```csharp


### PR DESCRIPTION
Unit Tests calling `ZeroFormatter` will always return the error:

    System.InvalidOperationException : Type is not supported, please register Player

After some hair scratching and re-reading your docs, I realised it's because the auto formatter registration for `RuntimeInitializeOnLoad` doesn't apply to unit tests. So by manually adding:

    ZeroFormatterInitializer.Register(); 

In test `SetUp` works fine. I thus updated the README. Feel free to re-word it.