### PR TITLE
Add explicit formatter declaration for ZeroFormattable attribute

### DIFF
--- a/src/ZeroFormatter.Interfaces.NETCore/ZeroFormatter.Interfaces.NETCore.csproj
+++ b/src/ZeroFormatter.Interfaces.NETCore/ZeroFormatter.Interfaces.NETCore.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ZeroFormatter.Interfaces/Attributes.cs
+++ b/src/ZeroFormatter.Interfaces/Attributes.cs
@@ -5,6 +5,7 @@ namespace ZeroFormatter
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
     public class ZeroFormattableAttribute : Attribute
     {
+        public Type FormatterType { get; set; }
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]

--- a/src/ZeroFormatter.NETCore/ZeroFormatter.NETCore.csproj
+++ b/src/ZeroFormatter.NETCore/ZeroFormatter.NETCore.csproj
@@ -26,20 +26,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.0.1" />
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-    <PackageReference Include="System.Collections" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Linq.Expressions" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.1.0" />
-    <PackageReference Include="System.Reflection" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-    <PackageReference Include="System.Text.Encoding" Version="4.0.11" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11" />
-    <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
-    <PackageReference Include="System.ObjectModel" Version="4.0.12" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Include="System.ObjectModel" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/ZeroFormatter.Tests/ZeroFormatter.Tests.csproj
+++ b/tests/ZeroFormatter.Tests/ZeroFormatter.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="EqTest.cs" />
     <Compile Include="VersiongTest.cs" />
     <Compile Include="ZeroArgumentTest.cs" />
+    <Compile Include="ZeroFormatterAttributeTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChainingAssertion.Ext.cs" />

--- a/tests/ZeroFormatter.Tests/ZeroFormatterAttributeTest.cs
+++ b/tests/ZeroFormatter.Tests/ZeroFormatterAttributeTest.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ZeroFormatter.Formatters;
+using ZeroFormatter.Internal;
+
+namespace ZeroFormatter.Tests
+{
+    [TestClass]
+    public class ZeroFormatterAttributeTest
+    {
+        [TestMethod]
+        public void Serialize()
+        {
+            var customClass = new CustomClass("Hello World");
+
+            var data = ZeroFormatterSerializer.Serialize(customClass);
+            var result = ZeroFormatterSerializer.Deserialize<CustomClass>(data);
+            result.Test.Is(customClass.Test);
+        }
+
+        [ZeroFormattable(FormatterType = typeof(CustomClassFormatter<>))]
+        public class CustomClass
+        {
+            public CustomClass(string test)
+            {
+                Test = test;
+            }
+
+            public string Test { get; }
+        }
+
+        public class CustomClassFormatter<TTypeResolver> : Formatter<TTypeResolver, CustomClass>
+            where TTypeResolver : ITypeResolver, new()
+        {
+            public override int? GetLength()
+            {
+                return null;
+            }
+
+            public override int Serialize(ref byte[] bytes, int offset, CustomClass value)
+            {
+                var stringLength = BinaryUtil.WriteString(ref bytes, offset + 4, value.Test);
+                BinaryUtil.WriteInt32Unsafe(ref bytes, offset, stringLength);
+                return stringLength + 4;
+            }
+
+            public override CustomClass Deserialize(ref byte[] bytes, int offset, DirtyTracker tracker,
+                out int byteSize)
+            {
+                var length = BinaryUtil.ReadInt32(ref bytes, offset);
+                byteSize = 4 + length;
+                return new CustomClass(BinaryUtil.ReadString(ref bytes, offset + 4, length));
+            }
+        }
+    }
+}


### PR DESCRIPTION
* add tests
* add checks in analyzer

I find it rather complicated having to register the formatters one after one. First, advanced logic is needed to register all resolvers from all referenced libraries (were should that code be put?) and it's uneconomical to keep track of all needed resolvers in a huge repository. I implemented a behavior like Json.Net and XmlSerializer are using: Every type knows it's formatter which is just used instead of resolving one (if it's set). The registering still has it's use when dealing with external types, but for custom types the `FormatterType` is a huge advantage.