### PR TITLE
 Fix GetBuiltinFormatter for ZeroFormattable generics

### DIFF
--- a/src/ZeroFormatter/Formatters/Formatter.cs
+++ b/src/ZeroFormatter/Formatters/Formatter.cs
@@ -702,6 +702,11 @@ namespace ZeroFormatter.Formatters
                 {
                     formatter = DynamicStructFormatter.Create<TTypeResolver, T>();
                 }
+
+                else if (HasZeroFormattableAttribute(ti))
+                {
+                    formatter = CreateDynamicFormatter<TTypeResolver, T>(ti);
+                }
             }
 
             else if (ti.GetCustomAttributes(typeof(UnionAttribute), false).FirstOrDefault() != null)
@@ -719,16 +724,9 @@ namespace ZeroFormatter.Formatters
                 }
             }
 
-            else if (ti.GetCustomAttributes(typeof(ZeroFormattableAttribute), true).FirstOrDefault() != null)
+            else if (HasZeroFormattableAttribute(ti))
             {
-                if (ti.IsValueType)
-                {
-                    formatter = DynamicStructFormatter.Create<TTypeResolver, T>();
-                }
-                else
-                {
-                    formatter = DynamicFormatter.Create<TTypeResolver, T>();
-                }
+                formatter = CreateDynamicFormatter<TTypeResolver, T>(ti);
             }
 
 #endif
@@ -736,7 +734,27 @@ namespace ZeroFormatter.Formatters
             return formatter;
         }
 
+
 #if !UNITY
+
+        static bool HasZeroFormattableAttribute(TypeInfo ti)
+        {
+            return ti.GetCustomAttributes(typeof(ZeroFormattableAttribute), true).FirstOrDefault() != null;
+        }
+
+        static object CreateDynamicFormatter<TTypeResolver, T>(TypeInfo ti)
+            where TTypeResolver : ITypeResolver, new()
+        {
+            if (ti.IsValueType)
+            {
+                return DynamicStructFormatter.Create<TTypeResolver, T>();
+            }
+            else
+            {
+                return DynamicFormatter.Create<TTypeResolver, T>();
+            }
+        }
+
 
         internal static void ResolveDynamicUnion(Type unionType, DynamicUnionResolver resolver)
         {

--- a/tests/ZeroFormatter.Tests/GenericTest.cs
+++ b/tests/ZeroFormatter.Tests/GenericTest.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ZeroFormatter.Formatters;
+
+namespace ZeroFormatter.Tests
+{
+    [TestClass]
+    public class GenericTest
+    {
+        [ZeroFormattable]
+        public struct MyGenericStruct<T>
+        {
+            [Index(0)]
+            public T x;
+            [Index(1)]
+            public int y;
+            [Index(2)]
+            public T z;
+
+            public MyGenericStruct(T x, int y, T z)
+            {
+                this.x = x;
+                this.y = y;
+                this.z = z;
+            }
+        }
+
+        [TestMethod]
+        public void GenericStruct()
+        {
+            var ofDouble = new MyGenericStruct<double>(100.4f, -3, 200.5f);
+
+            var ofDouble2 = ZeroFormatterSerializer.Convert(ofDouble);
+
+            ofDouble2.x.Is(100.4f);
+            ofDouble2.y.Is(-3);
+            ofDouble2.z.Is(200.5f);
+
+            var ofString = new MyGenericStruct<string>("", int.MaxValue, "abc");
+
+            var ofString2 = ZeroFormatterSerializer.Convert(ofString);
+
+            ofString2.x.Is("");
+            ofString2.y.Is(int.MaxValue);
+            ofString2.z.Is("abc");
+        }
+
+        [ZeroFormattable]
+        public struct MyGenericClass<T>
+        {
+            [Index(0)]
+            public T x;
+            [Index(1)]
+            public int y;
+
+            public MyGenericClass(T x, int y)
+            {
+                this.x = x;
+                this.y = y;
+            }
+        }
+
+        [TestMethod]
+        public void GenericClass()
+        {
+            var ofString = new MyGenericClass<string>("xyz", int.MinValue);
+
+            var ofString2 = ZeroFormatterSerializer.Convert(ofString);
+
+            ofString2.x.Is("xyz");
+            ofString2.y.Is(int.MinValue);
+
+            var ofMGS =
+                new MyGenericClass<MyGenericStruct<double>>(
+                    new MyGenericStruct<double>(0, 2, 3),
+                    int.MinValue);
+
+            var ofMGS2 = ZeroFormatterSerializer.Convert(ofMGS);
+
+            ofMGS2.x.x.Is(0d);
+            ofMGS2.x.y.Is(2);
+            ofMGS2.x.z.Is(3d);
+            ofMGS2.y.Is(int.MinValue);
+        }
+
+    }
+}

--- a/tests/ZeroFormatter.Tests/ZeroFormatter.Tests.csproj
+++ b/tests/ZeroFormatter.Tests/ZeroFormatter.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="InheritanceTest.cs" />
     <Compile Include="SomeResolverTest.cs" />
     <Compile Include="StructObject.cs" />
+    <Compile Include="GenericTest.cs" />
     <Compile Include="TupleFormatterTest.cs" />
     <Compile Include="DictionarySegmentTest.cs" />
     <Compile Include="FormatterTest.cs" />


### PR DESCRIPTION
Serialization currently fails for generic `[ZeroFormattable]` types such as those in the added test cases. It looks like the existing code supports generics just fine, but it doesn't get used because of a bug in the if/else tree in `GetBuiltinFormatter` :)